### PR TITLE
docker: Fix crash in docker_images

### DIFF
--- a/docker/src/agent_based/docker_images.py
+++ b/docker/src/agent_based/docker_images.py
@@ -52,6 +52,11 @@ def discover_docker_images(section_docker_images, section_docker_containers):
 
 def check_docker_images(item, section_docker_images, section_docker_containers):
     value_store = get_value_store()
+    if section_docker_containers:
+        docker_containers = section_docker_containers.values()
+    else:
+        docker_containers = []
+
     for line in section_docker_images:
 
         if line[0] == item:
@@ -61,7 +66,7 @@ def check_docker_images(item, section_docker_images, section_docker_containers):
                 (key, value) = kv.split("=", 1)
                 image[key] = value
 
-            image_containers = get_running_image_containers(image["ImageID"], section_docker_containers.values())
+            image_containers = get_running_image_containers(image["ImageID"], section_docker_containers)
             image["Running_containers"] = len(image_containers)
             image["Memory_used"] = sum(float(c["Memory_used"]) for c in image_containers)
             with suppress(GetRateError):


### PR DESCRIPTION
It looks to me as if `section_docker_containers` is always `None` - this PR at least makes the plugin not crash anymore.

# Crash Report
## Exception	

    AttributeError ('NoneType' object has no attribute 'values')

## Traceback	

```
  File "/omd/sites/zdv/lib/python3/cmk/base/agent_based/checking/_checking.py", line 413, in get_aggregated_result
    consume_check_results(
  File "/omd/sites/zdv/lib/python3/cmk/base/api/agent_based/checking_classes.py", line 484, in consume_check_results
    for subr in subresults:
  File "/omd/sites/zdv/lib/python3/cmk/base/api/agent_based/register/check_plugins.py", line 93, in filtered_generator
    for element in generator(*args, **kwargs):
  File "/omd/sites/zdv/local/lib/python3/cmk/base/plugins/agent_based/docker_images.py", line 64, in check_docker_images
    image_containers = get_running_image_containers(image["ImageID"], section_docker_containers.values())
```
## Local Variables	
```
{'image': {'Diskspace_used': '126307655',
           'ImageID': 'sha256:f8c66806716783cab3339b267973c135585d58ec0e626ca50d97375a05498236'},
 'item': 'dockerproxy.zdv.uni-mainz.de/library/redis:6.0',
 'key': 'Diskspace_used',
 'kv': 'Diskspace_used=126307655',
 'line': ['dockerproxy.zdv.uni-mainz.de/library/redis:6.0',
          'ImageID=sha256:f8c66806716783cab3339b267973c135585d58ec0e626ca50d97375a05498236',
          'Diskspace_used=126307655'],
 'section_docker_containers': None,
 'section_docker_images': [['registry.gitlab.rlp.net/zdvsysunix/docker-php/php82-fpm-infosys:test_latest',
                            'ImageID=sha256:20cc17efdea8bac38113ecd81d9dedf0f077d0c3a1f294062606792381893f54',
                            'Diskspace_used=234091056'],
                           ['dockerproxy.zdv.uni-mainz.de/library/redis:6.0',
                            'ImageID=sha256:f8c66806716783cab3339b267973c135585d58ec0e626ca50d97375a05498236',
                            'Diskspace_used=126307655'],
                           ['registry.gitlab.rlp.net/zdvsysunix/docker-php/php74-fpm-infosys-oracle:test_latest',
                            'ImageID=sha256:c577d59e2f2bc731e741de4f0579e4edac4517afa9e4f4abf3340ce58b1ce7ba',
                            'Diskspace_used=2591394349'],
                           ['registry.gitlab.rlp.net/zdvsysunix/docker-php/php82-fpm-infosys-oracle:test_latest',
                            'ImageID=sha256:0b6de5927d469c116593ad984e98e68f5910191a18a4bf2fcfaa82f22ad328e6',
                            'Diskspace_used=2812348442']],
 'value': '126307655',
 'value_store': <cmk.base.api.agent_based.value_store._utils._ValueStore object at 0x7fe360385250>}
```