### PR TITLE
Pure keyError crashes the check

### DIFF
--- a/pure/src/base/plugins/agent_based/pure_arraydetails.py
+++ b/pure/src/base/plugins/agent_based/pure_arraydetails.py
@@ -1,5 +1,6 @@
 
 #2023 created by Carlo Kleinloog
+#2024-06-11 Steve Parker - Code tweak to avoid KeyError crashing the check
 #/omd/sites/BIS/local/lib/python3/cmk/base/plugins/agent_based
 from cmk.base.check_api import get_bytes_human_readable, get_percent_human_readable
 
@@ -77,13 +78,13 @@ def check_pure_arraydetails(item, section):
             summary=f"Item {item} not found",
         )
 
-    data = section[item]
-    fs_snapshots:int=data['snapshots']
-    fs_provisioning:int=data['volumes']
-    fs_thin_provisioning=data['thin_provisioning']
-    fs_size:int=data['size']
-
     if item in section.keys():
+        data = section[item]
+        fs_snapshots:int=data['snapshots']
+        fs_provisioning:int=data['volumes']
+        fs_thin_provisioning=data['thin_provisioning']
+        fs_size:int=data['size']
+        perfdata=True
         yield Result(
             state=State.OK,
             summary=f"Provisioned Size: {get_bytes_human_readable(fs_size)}, Used after deduplication: {render.bytes(fs_provisioning)}",
@@ -92,22 +93,9 @@ def check_pure_arraydetails(item, section):
             Thin Provisioned: {fs_thin_provisioning} \n \
             Snapshots: {render.bytes(fs_snapshots)}",
             )
-# Metrics
-        yield Metric("pure_1_datareduction", float(data['data_reduction']))
-        yield Metric("pure_2_totalreduction", float(data['total_reduction']))
-        yield Metric("pure_3_thinprovisioned", float(fs_thin_provisioning))
-        yield Metric("pure_4_snaphots", int(fs_snapshots))
-    else:
-        yield Result(
-            state=State.CRIT,
-            summary=f"Provisioned Size: {get_bytes_human_readable(fs_size)}, Used after deduplication: {render.bytes(fs_provisioning)}",
-            details = f"Data Reduction: {data['data_reduction']} to 1 \n \
-            Total reduction: {data['total_reduction']} to 1 \n \
-            Thin Provisioned: {fs_thin_provisioning} \n \
-            Snapshots: {render.bytes(fs_snapshots)}",
-            )
 
 # Metrics
+    if perfdata is True:
         yield Metric("pure_1_datareduction", float(data['data_reduction']))
         yield Metric("pure_2_totalreduction", float(data['total_reduction']))
         yield Metric("pure_3_thinprovisioned", float(fs_thin_provisioning))

--- a/pure/src/base/plugins/agent_based/pure_arraydetails.py
+++ b/pure/src/base/plugins/agent_based/pure_arraydetails.py
@@ -71,7 +71,7 @@ def discovery_pure_arraydetails(section):
 
 def check_pure_arraydetails(item, section):
     failed = []
-
+    perfdata = False
     if item not in section.keys():
         yield Result(
             state=State.UNKNOWN,

--- a/pure/src/base/plugins/agent_based/pure_arrayperformance.py
+++ b/pure/src/base/plugins/agent_based/pure_arrayperformance.py
@@ -39,6 +39,7 @@ def discovery_pure_arrayperformance(section):
 
 def check_pure_arrayperformance(item, section):
     failed = []
+    perfdata = False
 
     if item not in section.keys():
         yield Result(

--- a/pure/src/base/plugins/agent_based/pure_arrayperformance.py
+++ b/pure/src/base/plugins/agent_based/pure_arrayperformance.py
@@ -1,5 +1,6 @@
 
 #2023 created by Carlo Kleinloog
+#2024-06-11 Steve Parker - Code tweak to avoid KeyError crashing the check
 #/omd/sites/BIS/local/lib/python3/cmk/base/plugins/agent_based
 
 from .agent_based_api.v1 import (
@@ -45,16 +46,16 @@ def check_pure_arrayperformance(item, section):
             summary=f"Item {item} not found",
         )
 
-    data=section[item]
-    disk_read_ios=data['reads_per_sec']
-    disk_write_ios=data['writes_per_sec']
-    disk_read_throughput=data['output_per_sec']
-    disk_write_throughput=data['input_per_sec']
-    disk_read_responsetime=data['usec_per_read_op']
-    disk_write_responsetime=data['usec_per_write_op']
-    perfdata=True
-
     if item in section.keys():
+        data=section[item]
+        disk_read_ios=data['reads_per_sec']
+        disk_write_ios=data['writes_per_sec']
+        disk_read_throughput=data['output_per_sec']
+        disk_write_throughput=data['input_per_sec']
+        disk_read_responsetime=data['usec_per_read_op']
+        disk_write_responsetime=data['usec_per_write_op']
+        perfdata=True
+
         yield Result(state=State.OK, notice = f"Read latency: {data['reads_per_sec']}\n \
             Write latency: {data['writes_per_sec']}\n \
             Flash Volume: Yes")


### PR DESCRIPTION
The check sometimes crashes when a volume is no longer present ,as the keyError is not captured. These code changes will make a disappeared volume go Unknown which I believe is the correct action.