### PR TITLE
Fix parsing in bacula_jobs

### DIFF
--- a/bacula_jobs/src/agents/plugins/bacula_jobs
+++ b/bacula_jobs/src/agents/plugins/bacula_jobs
@@ -31,7 +31,7 @@ if [ "$backend_type" = "pgsql" ]; then
         echo "psql executable cannot be found!" >&2
         exit 1
     fi
-    echo "Select JobId, Name, JobStatus, EndTime FROM Job WHERE EndTime BETWEEN NOW() - interval '30 days' AND NOW();" | sudo "$DB_HOST_OPT" -u "$dbuser" "$psql_bin" --tuples-only -AF $'\t'  "$dbname" "$dbuser"
+    echo "Select JobId, Name, JobStatus, EndTime FROM Job WHERE EndTime BETWEEN NOW() - interval '30 days' AND NOW();" | sudo "$DB_HOST_OPT" -u "$dbuser" "$psql_bin" --tuples-only -AF "$(printf '\t')"  "$dbname" "$dbuser"
 else
     # default: MySQL / MariaDB
     mysql_bin=$(which mysql)


### PR DESCRIPTION
The bacula_jobs plugin seems to have parsing issues when using `/bin/sh` and PostgreSQL Backend.

```shell
~ % sudo /bin/sh /usr/lib/check_mk_agent/plugins/bacula_jobs
```
Example output:
```
1234$\tMy Fancy Database Backup$\tT$\t2024-07-31 00:00:00
```

Of course you could change the shell interpreter in the shebang, but that would require that the selected interpreter is available on every system.
My chosen approach would be to adjust the insertion of the tabulator.