### PR TITLE
Cohesity - Add domain option for auth and allow password with dollar sign

### DIFF
--- a/cohesity/src/agents/special/agent_cohesity
+++ b/cohesity/src/agents/special/agent_cohesity
@@ -17,15 +17,16 @@ def usage():
     Print Usage
     """
     print("Cohesity Special Agent for Checkmk")
-    print("./agent_cohesity.py <VIP> <USERNAME> <PASSWORD>")
+    print("./agent_cohesity.py <VIP> <USERNAME> <PASSWORD> <DOMAIN>")
     sys.exit(0)
 
-if len(sys.argv) != 4:
+if len(sys.argv) != 5:
     usage()
 
 CLUSTER_VIP = sys.argv[1]
 USERNAME = sys.argv[2]
 PASSWORD = sys.argv[3]
+DOMAIN = sys.argv[4]
 API_URL = f'https://{CLUSTER_VIP}/irisservices/api/v1'
 
 def get_header():
@@ -35,7 +36,8 @@ def get_header():
 
     creds = json.dumps({
         "password": PASSWORD,
-        "username": USERNAME
+        "username": USERNAME,
+        "domain": DOMAIN
     })
 
     header = {

--- a/cohesity/src/checks/cohesity_agent
+++ b/cohesity/src/checks/cohesity_agent
@@ -28,7 +28,7 @@
 
 
 def agent_cohesity_arguments(params, hostname, ipaddress):
-    args = '%s %s %s' % (ipaddress, params['user'], params['password'])
+    args = "'%s' '%s' '%s' '%s'" % (ipaddress, params['user'], params['password'], params['domain'])
     return args
 
 special_agent_info['cohesity'] = agent_cohesity_arguments

--- a/cohesity/src/info
+++ b/cohesity/src/info
@@ -12,7 +12,7 @@
                    'plugins/wato/cohesity_agent.py']},
  'name': 'cohesity',
  'title': 'Cohesity checks',
- 'version': '1.3.3',
+ 'version': '1.3.4',
  'version.min_required': '2.0.0',
  'version.packaged': '2.0.0p6',
  'version.usable_until': None}

--- a/cohesity/src/web/plugins/wato/cohesity_agent.py
+++ b/cohesity/src/web/plugins/wato/cohesity_agent.py
@@ -22,6 +22,7 @@ def _valuespec_special_agents_cohesity():
         elements = [
             ("user", TextAscii(title = _("Username"), allow_empty = False)),
             ("password", Password(title = _("Password"), allow_empty = False)),
+            ("domain", TextAscii(title = _("Domain"), default_value = "LOCAL", allow_empty = False)),
         ],
         optional_keys=[],
     )


### PR DESCRIPTION
Hello @Bastian-Kuhn ,

About the Cohesity plugin. We need the domain for the authentication. This PR adds this option, default sets the domain to "LOCAL". Ref: https://developer.cohesity.com/apidocs/651/#/http/getting-started

Also we had issue with password including dollar sign not correctly interpreted in command line for the special agent. I added single quote to the command arguments.
I hope this is ok for you to accept this PR.
I changed the version to 1.3.4, but I didn't create a mkp.
BR