### PR TITLE
add versatility to qemu agent plugin

### DIFF
--- a/qemu/src/agents/plugins/qemu
+++ b/qemu/src/agents/plugins/qemu
@@ -22,7 +22,7 @@ if which virsh >/dev/null; then
             STATE=$(echo $L | awk '{print $3}')
             MEM=$(virsh dominfo $NAME | grep 'Used memory' | awk '{print $3}')
             let MEM=MEM/1024
-            PID=$(pgrep -f -- "/qemu-kvm .*-name $NAME ")
+            PID=$(pgrep -f -- "/qemu.*-name.*$NAME")
             if [ -n "$PID" ]; then
                     DATA=$(top -p $PID -n 1 -b | sed '${/^$/d}' | tail -1 | awk -- '{print $9" "$10}')
             else


### PR DESCRIPTION
Example of a process on Unraid (slackware based): `/usr/bin/qemu-system-x86_64 -name guest=vm-dev`

The included regex wouldn't work with this so I adapted it.