### PR TITLE
Cohesity: Improvements (metadata, storage, alerts, unprotected) - Fix (alerts) 

### DIFF
--- a/cohesity/src/agents/special/agent_cohesity
+++ b/cohesity/src/agents/special/agent_cohesity
@@ -115,8 +115,8 @@ def get_alerts():
     """
     Query API Alerts
     """
-    time_to = int(datetime.datetime.utcnow().timestamp())
-    time_from = time_to - 86400
+    time_to = int(datetime.datetime.now().timestamp() * 1_000_000)
+    time_from = time_to - (86400 * 1_000_000)
     url = f"/public/stats/alerts?startTimeUsecs={time_from}&endTimeUsecs={time_to}"
     print("<<<cohesity_alerts>>>")
     for key, value in get_url(url).items():

--- a/cohesity/src/agents/special/agent_cohesity
+++ b/cohesity/src/agents/special/agent_cohesity
@@ -101,6 +101,16 @@ def get_storage():
     for key, value in get_url('/public/stats/storage').items():
         print(f"{key} {value}")
 
+def get_metadata():
+    """
+    Get Metadata Information
+    """
+    print("<<<cohesity_metadata_usage>>>")
+    for key, value in get_url('/public/cluster').items():
+        if not isinstance(value, (int,float)):
+            continue
+        print(f"{key} {value}")
+
 def get_alerts():
     """
     Query API Alerts
@@ -127,6 +137,7 @@ def get_unprotected_objects():
 if __name__ == '__main__':
     get_cluster_status()
     get_storage()
+    get_metadata()
     get_alerts()
     get_unprotected_objects()
 

--- a/cohesity/src/base/plugins/agent_based/cohesity_metadata.py
+++ b/cohesity/src/base/plugins/agent_based/cohesity_metadata.py
@@ -1,0 +1,76 @@
+# 2021 created by Sven Rueß, sritd.de
+
+from .agent_based_api.v1 import (
+    Metric,
+    register,
+    Service,
+    Result,
+    State,
+    render,
+)
+
+
+def parse_cohesity_metadata(string_table):
+    section = {}
+    for row in string_table:
+        item = row[0]
+        
+        try:
+            number = float(row[1])
+        except ValueError:
+            number = 0
+
+        section[item] = number
+    return section
+
+
+register.agent_section(
+    name="cohesity_metadata_usage",
+    parse_function=parse_cohesity_metadata,
+)
+
+
+def discovery_cohesity_metadata(section):
+    yield Service()
+
+def check_cohesity_metadata(params, section):
+    (warn_pct, crit_pct) = params.get("levels %", (None, None))
+    used_metadata_space_pct = None
+    avail_metadata_space = None
+
+    if "usedMetadataSpacePct" in section.keys():
+        used_metadata_space_pct = section["usedMetadataSpacePct"]
+
+    if "availableMetadataSpace" in section.keys():
+        avail_metadata_space = section["availableMetadataSpace"]
+
+    text = f"Metadata space used: {render.percent(used_metadata_space_pct)} ({render.disksize(avail_metadata_space)} available)"
+
+    if None is not crit_pct and used_metadata_space_pct >= crit_pct:
+        yield Result(
+            state=State.CRIT,
+            summary=text,
+        )
+    elif None is not warn_pct and used_metadata_space_pct >= warn_pct:
+        yield Result(
+            state=State.WARN,
+            summary=text,
+        )
+    else:
+        yield Result(
+            state=State.OK,
+            summary=text,
+        )
+
+    yield Metric(name="used_metadata_space_pct", value=used_metadata_space_pct, levels=(warn_pct, crit_pct), boundaries=(0, 100))
+    yield Metric(name="avail_metadata_space", value=avail_metadata_space)
+
+register.check_plugin(
+    name="cohesity_metadata_usage",
+    service_name="Metadata Status",
+    discovery_function=discovery_cohesity_metadata,
+    check_function=check_cohesity_metadata,
+    check_default_parameters={},
+    check_ruleset_name="cohesity_metadata",
+)
+

--- a/cohesity/src/base/plugins/agent_based/cohesity_storage.py
+++ b/cohesity/src/base/plugins/agent_based/cohesity_storage.py
@@ -1,6 +1,7 @@
 # 2021 created by Sven Rueß, sritd.de
 
 from .agent_based_api.v1 import (
+    Metric,
     register,
     Service,
     Result,
@@ -34,6 +35,7 @@ def discovery_cohesity_storage(section):
 
 def check_cohesity_storage(params, section):
     (warn, crit) = params.get("levels", (None, None))
+    (warn_pct, crit_pct) = params.get("levels %", (None, None))
     used_storage = None
     total_storage = None
 
@@ -51,7 +53,17 @@ def check_cohesity_storage(params, section):
             state=State.CRIT,
             summary=text,
         )
+    elif None is not crit_pct and percent_used >= crit_pct:
+        yield Result(
+            state=State.CRIT,
+            summary=text,
+        )
     elif None is not warn and used_storage >= warn:
+        yield Result(
+            state=State.WARN,
+            summary=text,
+        )
+    elif None is not warn_pct and percent_used >= warn_pct:
         yield Result(
             state=State.WARN,
             summary=text,
@@ -62,6 +74,8 @@ def check_cohesity_storage(params, section):
             summary=text,
         )
 
+    yield Metric(name="used_storage", value=used_storage, levels=(warn, crit), boundaries=(0, total_storage))
+    yield Metric(name="percent_used", value=percent_used, levels=(warn_pct, crit_pct), boundaries=(0, 100))
 
 register.check_plugin(
     name="cohesity_storage_usage",

--- a/cohesity/src/base/plugins/agent_based/cohesity_unprotected.py
+++ b/cohesity/src/base/plugins/agent_based/cohesity_unprotected.py
@@ -1,6 +1,7 @@
 # 2021 created by Sven Rueß, sritd.de
 
 from .agent_based_api.v1 import (
+    Metric,
     register,
     Service,
     Result,
@@ -49,6 +50,7 @@ def check_cohesity_unprotected(section):
             details=f"Size of protected objects: {render.bytes(section['protectedSizeBytes'])}"
         )
 
+    yield Metric(name="unprotected_objects", value=section["numObjectsUnprotected"])
 
 register.check_plugin(
     name="cohesity_unprotected",

--- a/cohesity/src/web/plugins/wato/cohesity_metadata.py
+++ b/cohesity/src/web/plugins/wato/cohesity_metadata.py
@@ -1,0 +1,40 @@
+# 2021 created by Sven Rueß, sritd.de
+
+from cmk.gui.i18n import _
+from cmk.gui.valuespec import (
+    Dictionary,
+    Tuple,
+    Percentage
+)
+from cmk.gui.plugins.wato import (
+    CheckParameterRulespecWithoutItem,
+    rulespec_registry,
+    RulespecGroupCheckParametersApplications,
+)
+
+
+def _parameter_valuespec_cohesity_metadata():
+    return Dictionary(
+        elements = [
+            ("levels %", Tuple(
+                title=_("Maximum percent usage of cluster metadata"),
+                help=_("Please configure levels for maximum percent used metadata of cluster."),
+                elements=[
+                    Percentage(title=_("Warning at")),
+                    Percentage(title=_("Critical at")),
+                ],
+            )),
+        ],
+    )
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithoutItem(
+        check_group_name="cohesity_metadata",
+        group=RulespecGroupCheckParametersApplications,
+        match_type="dict",
+        parameter_valuespec=_parameter_valuespec_cohesity_metadata,
+        title=lambda: _("Cohesity metadata usage"),
+    )
+)
+

--- a/cohesity/src/web/plugins/wato/cohesity_storage.py
+++ b/cohesity/src/web/plugins/wato/cohesity_storage.py
@@ -5,6 +5,7 @@ from cmk.gui.valuespec import (
     Dictionary,
     Tuple,
     Filesize,
+    Percentage,
 )
 from cmk.gui.plugins.wato import (
     CheckParameterRulespecWithoutItem,
@@ -24,12 +25,20 @@ def _parameter_valuespec_cohesity_storage():
                     Filesize(title=_("Critical at")),
                 ],
             )),
+            ("levels %", Tuple(
+                title=_("Maximum percent size of cluster filesystem"),
+                help=_("Please configure levels for maximum percent used filesystem size of cluster."),
+                elements=[
+                    Percentage(title=_("Warning at")),
+                    Percentage(title=_("Critical at")),
+                ],
+            )),
         ],
     )
 
 
 rulespec_registry.register(
-    CheckParameterRulespecWithItem(
+    CheckParameterRulespecWithoutItem(
         check_group_name="cohesity_storage",
         group=RulespecGroupCheckParametersApplications,
         match_type="dict",


### PR DESCRIPTION
Hello @Bastian-Kuhn 
Here are some commits for Cohesity plugin improvements and fix:

- New check for Metadata usage
- Review of Alert status with differentiation of Critical, Warning and Info alerts. Return Critical status if at least one critical alert, Warning if at least one warning alert but no critical, Ok if only info alert. Also a fix of the timeperiod for the query as it must be in Usec instead of sec. More details in the summary output.
- Add perfdata to Storage check, and GUI option to set percent thresholds
- Add perfdata to Unprotected check

Best regards
Nicolas